### PR TITLE
feat: Add a sync implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ tokio-stream = "0.1"
 [dev-dependencies]
 env_logger = "0.9"
 rand = "0.8"
-tokio = { version = "1.17", features = ["macros", "net", "rt", "sync"] }
+tokio = { version = "1.17", features = ["macros", "net", "rt-multi-thread", "sync"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,6 @@
 use std::{ffi::OsString, path::Path};
 
-use crate::{Connection, Result};
+use crate::{Connection, Result, SyncConnection};
 
 /// A bird client instance. You need to create a [Connection] from this
 /// client, using [Client::connect], to make requests.
@@ -31,5 +31,14 @@ impl Client {
     /// initial hello negotiation with the server fails.
     pub async fn connect(&self) -> Result<Connection> {
         Connection::new(&self.unix_socket).await
+    }
+
+    /// Open a new [SyncConnection] to this client. You can open multiple
+    /// connections to the same client.
+    ///
+    /// Note that this can fail if the unix socket is closed, or if the
+    /// initial hello negotiation with the server fails.
+    pub fn connect_sync(&self) -> Result<SyncConnection> {
+        SyncConnection::new(&self.unix_socket)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! Library for async communication with the Bird BGP server.
+//! Library for communication with the Bird BGP server, supporting both sync and async.
 //!
 //! ## Examples
 //! ```no_run

--- a/src/models/interface.rs
+++ b/src/models/interface.rs
@@ -23,7 +23,7 @@ impl Interface {
             let name = if let Some(s) = it.next() {
                 s
             } else {
-                log::error!("ifc: unable to determine name in {}", content);
+                log::error!("ifc: unable to determine name in {content}");
                 return None;
             };
 
@@ -33,12 +33,12 @@ impl Interface {
                     "up" => true,
                     "down" => false,
                     _ => {
-                        log::error!("ifc: unknown state {}", s);
+                        log::error!("ifc: unknown state {s}");
                         return None;
                     }
                 }
             } else {
-                log::error!("ifc: unable to determine state in {}", content);
+                log::error!("ifc: unable to determine state in {content}");
                 return None;
             };
 
@@ -54,7 +54,7 @@ impl Interface {
                 }
             }
             if index < 0 {
-                log::error!("ifc: did not find an appropriate index in {}", content);
+                log::error!("ifc: did not find an appropriate index in {content}");
                 return None;
             }
 
@@ -98,7 +98,7 @@ impl InterfaceProperties {
                     _ => InterfaceType::Unknown(s.to_owned()),
                 }
             } else {
-                log::error!("ifc: did not find any iftype in {}", content);
+                log::error!("ifc: did not find any iftype in {content}");
                 return None;
             };
             for token in content.split_ascii_whitespace() {
@@ -106,7 +106,7 @@ impl InterfaceProperties {
                     if let Ok(m) = _mtu.parse::<u32>() {
                         mtu = m;
                     } else {
-                        log::error!("ifc: found invalid mtu in line {}", content);
+                        log::error!("ifc: found invalid mtu in line {content}");
                         return None;
                     }
                 } else {
@@ -125,7 +125,7 @@ impl InterfaceProperties {
             }
 
             if mtu == 0 {
-                log::error!("ifc: did not find any iftype in {}", content);
+                log::error!("ifc: did not find any iftype in {content}");
             }
 
             Some(InterfaceProperties { iftype, flags, mtu })
@@ -208,7 +208,7 @@ impl InterfaceAddress {
                 let ip = if let Some(s) = it.next() {
                     s
                 } else {
-                    log::error!("ifc: failed to find ip address in {}", line);
+                    log::error!("ifc: failed to find ip address in {line}");
                     return None;
                 };
 
@@ -220,7 +220,7 @@ impl InterfaceAddress {
                         if let Some(sc) = it.next() {
                             scope = sc.trim_matches(bc).trim_matches(',');
                         } else {
-                            log::error!("ifc: encountered scope but not value in {}", line);
+                            log::error!("ifc: encountered scope but not value in {line}");
                             return None;
                         }
                     } else {
@@ -299,6 +299,19 @@ impl InterfaceSummary {
         }
     }
 }
+
+/// Valid broadcast address set
+const IF_FLAG_BROADCAST: u32 = 1 << 2;
+/// Supports multicast
+const IF_FLAG_MULTICAST: u32 = 1 << 3;
+/// Is a loopback device
+const IF_FLAG_LOOPBACK: u32 = 1 << 5;
+/// Not to be used by routing protocols (loopbacks etc.)
+const IF_FLAG_IGNORED: u32 = 1 << 6;
+/// Interface is running
+const IF_FLAG_ADMIN_UP: u32 = 1 << 7;
+/// L1 layer is up
+const IF_FLAG_LINK_UP: u32 = 1 << 8;
 
 #[cfg(test)]
 mod tests {
@@ -413,16 +426,3 @@ mod tests {
         }
     }
 }
-
-/// Valid broadcast address set
-const IF_FLAG_BROADCAST: u32 = 1 << 2;
-/// Supports multicast
-const IF_FLAG_MULTICAST: u32 = 1 << 3;
-/// Is a loopback device
-const IF_FLAG_LOOPBACK: u32 = 1 << 5;
-/// Not to be used by routing protocols (loopbacks etc.)
-const IF_FLAG_IGNORED: u32 = 1 << 6;
-/// Interface is running
-const IF_FLAG_ADMIN_UP: u32 = 1 << 7;
-/// L1 layer is up
-const IF_FLAG_LINK_UP: u32 = 1 << 8;

--- a/src/models/status.rs
+++ b/src/models/status.rs
@@ -40,21 +40,21 @@ impl ShowStatusMessage {
                             if let Ok(dt) = NaiveDateTime::parse_from_str(x.trim(), tfmt) {
                                 server_time = Some(dt);
                             } else {
-                                log::error!("failed to parse timestamp {}", x);
+                                log::error!("failed to parse timestamp {x}");
                                 return None;
                             }
                         } else if let Some(x) = line.strip_prefix("Last reboot on ") {
                             if let Ok(dt) = NaiveDateTime::parse_from_str(x.trim(), tfmt) {
                                 last_reboot_on = Some(dt);
                             } else {
-                                log::error!("failed to parse timestamp {}", x);
+                                log::error!("failed to parse timestamp {x}");
                                 return None;
                             }
                         } else if let Some(x) = line.strip_prefix("Last reconfiguration on ") {
                             if let Ok(dt) = NaiveDateTime::parse_from_str(x.trim(), tfmt) {
                                 last_reconfigured_on = Some(dt);
                             } else {
-                                log::error!("failed to parse timestamp {}", x);
+                                log::error!("failed to parse timestamp {x}");
                                 return None;
                             }
                         }

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -90,7 +90,7 @@ impl MockServer {
                             );
                             if delay_ms > 0 {
                                 for ref c in split_content(response) {
-                                    log::trace!("sending chunk: {}", c);
+                                    log::trace!("sending chunk: {c}");
                                     Self::write_to_client(&stream, c).await;
                                     tokio::time::sleep(Duration::from_millis(delay_ms)).await;
                                 }
@@ -103,7 +103,7 @@ impl MockServer {
                     }
                     Err(err) => {
                         if err.kind() != std::io::ErrorKind::WouldBlock {
-                            panic!("server: encountered IO error: {}", err);
+                            panic!("server: encountered IO error: {err}");
                         }
                     }
                 }
@@ -136,8 +136,7 @@ impl MockServer {
             let expired = Instant::now().duration_since(start) > duration;
             assert!(
                 !expired,
-                "timed out waiting for {} client connections",
-                num_clients
+                "timed out waiting for {num_clients} client connections"
             );
             tokio::time::sleep(Duration::from_millis(100)).await;
         }


### PR DESCRIPTION
Adds a sync implementation of the `Connection` type, `SyncConnection`. This is accomplished by moving all message parsing logic out of `Connection` to be reused by both implementations, and then duplicating the minimum required functions to `SyncConnection`. This is what I've found to be the cleanest path forward, but I'm open to other ideas.
There's also some linting errors that have been fixed with clippy via version 0.1.88, if preferred I can move those into a separate pull request

Closes #2 